### PR TITLE
Use `.` in place of `source`

### DIFF
--- a/streamcontroller_plugin_tools/installation_helpers.py
+++ b/streamcontroller_plugin_tools/installation_helpers.py
@@ -7,5 +7,5 @@ def create_venv(path: str = ".venv", path_to_requirements_txt: str = None) -> No
 
     if path_to_requirements_txt is None:
         return
-    print(f"source {join(path, 'bin', 'activate')} && pip install -r {path_to_requirements_txt}")
-    run(f"source {join(path, 'bin', 'activate')} && pip install -r {path_to_requirements_txt}", start_new_session=True, shell=True)
+    print(f". {join(path, 'bin', 'activate')} && pip install -r {path_to_requirements_txt}")
+    run(f". {join(path, 'bin', 'activate')} && pip install -r {path_to_requirements_txt}", start_new_session=True, shell=True)


### PR DESCRIPTION
Python runs this command with the POSIX shell, so this patch removes the Bash-ism `source`.

See https://github.com/StreamController/StreamController/issues/192.