### PR TITLE
fix(rpyc)(#3): add config to be->fe connection

### DIFF
--- a/streamcontroller_plugin_tools/BackendBase.py
+++ b/streamcontroller_plugin_tools/BackendBase.py
@@ -23,7 +23,7 @@ class BackendBase(rpyc.Service):
 
     def connect_to_frontend(self):
         port = self.get_args().port
-        self.frontend_connection = rpyc.connect("localhost", port)
+        self.frontend_connection = rpyc.connect("localhost", port, config={"allow_public_attrs": True})
         self.frontend = self.frontend_connection.root
 
     def start_server(self):


### PR DESCRIPTION
* Adds config to backend-to-frontend connection with same semantics as the backend server in BackendBase.
* This change is not intended to change data accessibility beyond what is semantically expected, and as such does not add further affordances like set_attr (which would allow property setters) or other useful RPyC permissions.

## Testing

As impact from this omission was not detected in StreamController/StreamController#329, no testing or validation was performed.